### PR TITLE
adds PyQt6-WebEngine requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     zip_safe=False,
     install_requires=[
         "PyQt6>=6.0.0",
-        "PyQt6-WebEngine>=6.0.0"
+        "PyQt6-WebEngine>=6.0.0",
         "Flask>=2.0.0",
         "openslide-python>=1.1.2",
         "Pillow>=8.2.0",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setuptools.setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        "PyQt6>=6.0.0",
+        "PyQt6-WebEngine>=6.0.0"
         "Flask>=2.0.0",
         "openslide-python>=1.1.2",
         "Pillow>=8.2.0",


### PR DESCRIPTION
Installing TissUUmaps on Mac from scratch requires these packages to launch the GUI, both available via `pip`:
```
PyQt6>=6.0.0
PyQt6-WebEngine>=6.0.0
```
The versions are based on the versions I got from installing them (which solves the issues in Mac):
```
PyQt6                             6.4.0
PyQt6-Qt6                     6.4.1
PyQt6-sip                      13.4.0
PyQt6-WebEngine         6.4.0
PyQt6-WebEngine-Qt6 6.4.1
```

