### PR TITLE
Rendering improvements for 3.2.1

### DIFF
--- a/tissuumaps/static/js/utils/glUtils.js
+++ b/tissuumaps/static/js/utils/glUtils.js
@@ -1509,6 +1509,11 @@ glUtils._updateBarcodeToLUTIndexDict = function (uid, markerData, keyName, maxNu
                                              // since this causes problems with pie-chart markers
         }
     }
+    if (Object.keys(barcodeToLUTIndex).length > maxNumBarcodes) {
+        interfaceUtils.generateNotification("Markerset contains more than " + maxNumBarcodes +
+            " number of unique keys or groups. Some parts of the visualization " +
+            "(colors and selection) might not work correctly.", "barcode_warning", false, false);
+    }
     glUtils._barcodeToLUTIndex[uid] = barcodeToLUTIndex;
     glUtils._barcodeToKey[uid] = barcodeToKey;
     console.log("barcodeToLUTIndex, barcodeToKey", barcodeToLUTIndex, barcodeToKey);

--- a/tissuumaps/static/js/utils/glUtils.js
+++ b/tissuumaps/static/js/utils/glUtils.js
@@ -2086,7 +2086,7 @@ glUtils._drawMarkersByUID = function(gl, viewportTransform, markerScaleAdjusted,
     // Set per-markerset uniforms
     gl.uniform1i(gl.getUniformLocation(program, "u_transformIndex"),
         glUtils._collectionItemIndex[uid] != null ? glUtils._collectionItemIndex[uid] : -1);
-    gl.uniform1f(gl.getUniformLocation(program, "u_markerScale"), glUtils._markerScaleFactor[uid]);
+    gl.uniform1f(gl.getUniformLocation(program, "u_markerScale"), (glUtils._useAbsoluteMarkerSize[uid] ? glUtils._markerScale * 0.25 : 1.0) * glUtils._markerScaleFactor[uid]);
     gl.uniform2fv(gl.getUniformLocation(program, "u_markerScalarRange"), glUtils._markerScalarRange[uid]);
     gl.uniform1f(gl.getUniformLocation(program, "u_markerOpacity"), glUtils._markerOpacity[uid]);
     gl.uniform1f(gl.getUniformLocation(program, "u_markerStrokeWidth"), glUtils._markerStrokeWidth[uid]);

--- a/tissuumaps/static/js/utils/glUtils.js
+++ b/tissuumaps/static/js/utils/glUtils.js
@@ -21,15 +21,15 @@ glUtils = {
     _query: null,
     _caps: {},
 
-    // Marker settings and info stored per UID (this could perhaps be
-    // better handled by having an object per UID that stores all info
-    // and is easy to delete when closing a marker tab...)
+    // Marker rendering settings and info stored per UID (this could perhaps be
+    // better handled by having an object per UID that stores all info and is
+    // easy to delete when closing a marker tab...)
     _numPoints: {},              // {uid: numPoints, ...}
     _numEdges: {},               // {uid: numEdges, ...}
     _zOrder: {},                 // {uid: float, ...}
     _markerScalarRange: {},      // {uid: [minval, maxval], ...}
-    _markerScaleFactor: {},      // {uid: float}
     _markerScalarPropertyName: {},  // {uid: string, ...}
+    _markerScaleFactor: {},      // {uid: float, ...}
     _markerOpacity: {},          // {uid: alpha, ...}
     _markerStrokeWidth: {},      // {uid: float, ...}
     _markerFilled: {},           // {uid: boolean, ...}
@@ -50,7 +50,7 @@ glUtils = {
     _markerInputsCached: {},     // {uid: dict, ...}
     _edgeInputsCached: {},       // {uid: dict, ...}
 
-    // Global marker settings and info
+    // Global marker rendering settings and info
     _markerScale: 1.0,
     _useMarkerScaleFix: true,
     _globalMarkerScale: 1.0,
@@ -64,6 +64,8 @@ glUtils = {
     _useInstancing: true,         // Use instancing and gl.TRIANGLE_STRIP to avoid size limit of gl.POINTS
     _showEdgesExperimental: true,
     _edgeThicknessRatio: 0.1,     // Ratio between edge thickness and marker size
+
+    // Global region rendering settings and info
     _regionOpacity: 0.5,
     _regionStrokeWidth: 1.0,      // Base stroke width in pixels (larger values can give artifacts, so use with care!)
     _regionFillRule: "never",     // Possible values: "never" | "nonzero" | "oddeven"
@@ -73,6 +75,8 @@ glUtils = {
     _regionDataSize: {},          // Size stored per region data texture and used for dynamic resizing
     _regionPicked: null,          // Key to regionUtils._regions dict, or null if no region is picked
     _regionMaxNumRegions: 524288, // Limit used for the LUT texture size (will be automatically increased if needed)
+
+    // Other settings
     _logPerformance: false,       // Use GPU timer queries to log performance
     _piechartPaletteDefault: ["#fff100", "#ff8c00", "#e81123", "#ec008c", "#68217a", "#00188f", "#00bcf2", "#00b294", "#009e49", "#bad80a"]
 }

--- a/tissuumaps/static/js/utils/regionUtils.js
+++ b/tissuumaps/static/js/utils/regionUtils.js
@@ -69,6 +69,11 @@ regionUtils.getLayerFromCoord = function (coordinates) {
         let imageCoord = tiledImage.viewportToImageCoordinates(
             coordinates.x, coordinates.y, true
         );
+        if (tiledImage.getFlip()) {
+            // TiledImage.viewportToImageCoordinates() does not take
+            // flip into account, so need to apply it manually here
+            imageCoord.x = tiledImage.getContentSize().x - imageCoord.x;
+        }
         if (imageCoord.x > 0 && imageCoord.y > 0 &&
             imageCoord.x < tiledImage.getContentSize().x && imageCoord.y < tiledImage.getContentSize().y) {
                 return i;
@@ -94,6 +99,11 @@ regionUtils.globalPointsToViewportPoints = function (globalPoints, layerIndex) {
                 let x = globalPoints[i][j][k].x;
                 let y = globalPoints[i][j][k].y;
                 let tiledImage = viewer.world.getItemAt(layerIndex);
+                if (tiledImage.getFlip()) {
+                    // TiledImage.imageToViewportCoordinates() does not take
+                    // flip into account, so need to apply it manually here
+                    x = tiledImage.getContentSize().x - x;
+                }
                 let imageCoord = tiledImage.imageToViewportCoordinates(
                     x, y, true
                 );
@@ -127,6 +137,11 @@ regionUtils.viewportPointsToGlobalPoints = function (viewportPoints, layerIndex)
                 let imageCoord = tiledImage.viewportToImageCoordinates(
                     x, y, true
                 );
+                if (tiledImage.getFlip()) {
+                    // TiledImage.viewportToImageCoordinates() does not take
+                    // flip into account, so need to apply it manually here
+                    imageCoord.x = tiledImage.getContentSize().x - imageCoord.x;
+                }
                 polygon.push({ "x": imageCoord.x, "y": imageCoord.y });
             }
             subregion.push(polygon);
@@ -493,6 +508,11 @@ regionUtils.addRegion = function (points, regionid, color, regionClass, collecti
                     let imageCoord = tiledImage.viewportToImageCoordinates(
                         x, y, true
                     );
+                    if (tiledImage.getFlip()) {
+                        // TiledImage.viewportToImageCoordinates() does not take
+                        // flip into account, so need to apply it manually here
+                        imageCoord.x = tiledImage.getContentSize().x - imageCoord.x;
+                    }
                     x = imageCoord.x;
                     y = imageCoord.y;
                 }
@@ -2267,6 +2287,11 @@ regionUtils._findRegionByPoint = function(position) {
         const scanlineHeight = imageBounds[3] / numScanlines;
 
         const imageCoord = image.viewerElementToImageCoordinates(position);
+        if (image.getFlip()) {
+            // TiledImage.viewerElementToCoordinates() does not take flip into
+            // account, so need to apply it manually here
+            imageCoord.x = image.getContentSize().x - imageCoord.x;
+        }
         const px = imageCoord.x;
         const py = imageCoord.y;
         const scanline = Math.floor(py / scanlineHeight);


### PR DESCRIPTION
- [ ] Markers
  - [ ] Add "Rotate by marker" option
  - [x] Add option to use image coordinates as unit for "Use different size per marker" and/or "Size factor"
  - [ ] "Adapt on zoom" for marker outlines
  - [x] Add MAX blending and other blend modes as alternative to current OVER operator
  - [ ] Custom 2D colormaps that take two scalar inputs (UMAP1 and UMAP2 coordinates for example)
  - [ ] Replace quad trees with simpler data structure (uniform grid with bins) that is faster to build and more memory efficient for large datasets
  - [x] Show warning if number of unique barcodes or marker groups exceeds the LUT capacity
- [ ] Edges/connections
  - [ ] Add "Color by weight" option
  - [ ] Add "Scale by weight" option
  - [x] Split draw calls into smaller chunks like for marker rendering
- [ ] Regions
  - [ ] Replace some rendering where we still use SVG instead of WebGL (like drawing selection outlines)
  - [ ] Split region paths into segments/chunks (with up to N edges in each) to better handle cases where many edges from the same path bin into the same scanline
  - [ ] Decrease number of scanlines to reduce artifacts when rendering thick strokes
  - [x] Fix incorrect transforms of region points when image layer is flipped